### PR TITLE
update httparty from 0.5.0 to 0.13.7

### DIFF
--- a/url_shortener.gemspec
+++ b/url_shortener.gemspec
@@ -50,14 +50,14 @@ Gem::Specification.new do |s|
     s.specification_version = 2
     
     if Gem::Version.new(Gem::RubyGemsVersion) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<httparty>, ["~> 0.5.0"])
+      s.add_runtime_dependency(%q<httparty>, ["~> 0.13.7"])
       s.add_runtime_dependency(%q<hashie>, ["~> 1.2.0"])
     else
-      s.add_dependency(%q<httparty>, ["~> 0.5.0"])
+      s.add_dependency(%q<httparty>, ["~> 0.13.7"])
       s.add_dependency(%q<hashie>, ["~> 1.2.0"])
     end
   else
-    s.add_dependency(%q<httparty>, ["~> 0.5.0"])
+    s.add_dependency(%q<httparty>, ["~> 0.13.7"])
     s.add_dependency(%q<hashie>, ["~> 1.2.0"])
   end
 end


### PR DESCRIPTION
This no longer works with newer versions of Rails. 
It throws the error 
```
*** NoMethodError Exception: undefined method `to_params' for #<Hash:0x007f9643424ec0>
```
 when calling client.shorten.

Updating httparty to the latest version fixes this issue